### PR TITLE
perf/Setear a axios para que envíe credenciales/cookies por default

### DIFF
--- a/src/store/actions/index.js
+++ b/src/store/actions/index.js
@@ -1,5 +1,5 @@
 import axios from "axios";
-
+axios.defaults.withCredentials = true; // Setear que axios, por default, envíe cookie. Su valor por default es false.
 import {
   URL_ALLPETS,
   URL_PET_DETAIL,


### PR DESCRIPTION
- Setear en la cabeza de src/store/actions una modificación en una propiedad de axios.
- Por qué? Porque por default axios no envía cookies. Viene seteada en false la propiedad ["withCredentials"] la cual es la que establece un header específico y permite el envío de cookies.
- Lo testié con una sola action y dió los resultados positivos esperados.

Para referencia:
 https://stackoverflow.com/questions/43002444/make-axios-send-cookies-in-its-requests-automatically